### PR TITLE
Harden pipeline_core orchestration and logging

### DIFF
--- a/pipeline_core/fetchers.py
+++ b/pipeline_core/fetchers.py
@@ -63,16 +63,27 @@ class FetcherOrchestrator:
                         pool.submit(self._run_provider_fetch, provider_conf, query, filters)
                     )
 
-            try:
-                timeout_s = max(self.config.request_timeout_s, 0.1)
-                for fut in concurrent.futures.as_completed(futures, timeout=timeout_s):
-                    elapsed = time.perf_counter() - start
-                    if elapsed >= timeout_s:
-                        break
+            timeout_s = max(self.config.request_timeout_s, 0.1)
+            deadline = start + timeout_s
+            pending = set(futures)
+            while pending and len(results) < self.config.per_segment_limit:
+                remaining = deadline - time.perf_counter()
+                if remaining <= 0:
+                    break
+                done, pending = concurrent.futures.wait(
+                    pending,
+                    timeout=remaining,
+                    return_when=concurrent.futures.FIRST_COMPLETED,
+                )
+                if not done:
+                    break
+                for fut in done:
                     try:
                         candidates = fut.result() or []
+                    except concurrent.futures.TimeoutError:
+                        continue
                     except Exception:
-                        candidates = []
+                        continue
                     if not candidates:
                         continue
                     for candidate in candidates:
@@ -80,10 +91,8 @@ class FetcherOrchestrator:
                             results.append(candidate)
                             if len(results) >= self.config.per_segment_limit:
                                 break
-                    if len(results) >= self.config.per_segment_limit:
-                        break
-            except concurrent.futures.TimeoutError:
-                pass
+            for fut in pending:
+                fut.cancel()
 
         return results[: self.config.per_segment_limit]
 
@@ -93,10 +102,27 @@ class FetcherOrchestrator:
     def _run_provider_fetch(self, provider_conf, query: str, filters: Optional[dict]) -> List[RemoteAssetCandidate]:
         name = provider_conf.name.lower()
         limit = max(1, provider_conf.max_results or self.config.per_segment_limit)
-        if name == "pexels":
-            return self._fetch_from_pexels(query, limit)
-        if name == "pixabay":
-            return self._fetch_from_pixabay(query, limit)
+        timeout = provider_conf.timeout_s or self.config.request_timeout_s
+        timeout = max(timeout, 0.1)
+        attempts = max(1, self.config.retry_count)
+
+        def _dispatch() -> List[RemoteAssetCandidate]:
+            if name == "pexels":
+                return self._fetch_from_pexels(query, limit)
+            if name == "pixabay":
+                return self._fetch_from_pixabay(query, limit)
+            return []
+
+        for attempt in range(attempts):
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as gate:
+                future = gate.submit(_dispatch)
+                try:
+                    return future.result(timeout=timeout)
+                except concurrent.futures.TimeoutError:
+                    continue
+                except Exception:
+                    if attempt == attempts - 1:
+                        return []
         return []
 
     def _fetch_from_pexels(self, query: str, limit: int) -> List[RemoteAssetCandidate]:

--- a/pipeline_core/llm_service.py
+++ b/pipeline_core/llm_service.py
@@ -7,6 +7,7 @@ import logging
 import sys
 from pathlib import Path
 import importlib.util
+import re
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
@@ -81,12 +82,20 @@ class LLMMetadataGeneratorService:
             with self._lock:
                 if self._shared_integration is None:
                     logger.info("[LLM] Initialising shared pipeline integration")
-                    self._shared_integration = create_pipeline_integration()
+                    try:
+                        self._shared_integration = create_pipeline_integration()
+                    except Exception:  # pragma: no cover - defensive logging
+                        logger.exception("[LLM] Failed to initialise shared pipeline integration")
+                        raise
                     LLMMetadataGeneratorService._init_count += 1
             return self._shared_integration
         if self._integration is None:
             logger.info("[LLM] Initialising local pipeline integration")
-            self._integration = create_pipeline_integration()
+            try:
+                self._integration = create_pipeline_integration()
+            except Exception:  # pragma: no cover - defensive logging
+                logger.exception("[LLM] Failed to initialise local pipeline integration")
+                raise
         return self._integration
 
     def generate_metadata(

--- a/pipeline_core/logging.py
+++ b/pipeline_core/logging.py
@@ -46,21 +46,24 @@ def log_broll_decision(
     llm_healthy: bool,
     reject_reasons: List[str],
 ) -> None:
-    logger.log(
-        {
-            "segment": segment_idx,
-            "t0": start,
-            "t1": end,
-            "q_count": query_count,
-            "candidates": candidate_count,
-            "unique_candidates": unique_candidates,
-            "dedup_url_hits": url_dedup_hits,
-            "dedup_phash_hits": phash_dedup_hits,
-            "selected_url": selected_url,
-            "selected_score": selected_score,
-            "provider": provider,
-            "latency_ms": latency_ms,
-            "llm_healthy": llm_healthy,
-            "reject_reasons": reject_reasons,
-        }
-    )
+    event_name = "broll_segment_decision"
+    if segment_idx < 0:
+        event_name = "broll_session_summary"
+    payload = {
+        "event": event_name,
+        "segment": segment_idx,
+        "t0": start,
+        "t1": end,
+        "q_count": query_count,
+        "candidates": candidate_count,
+        "unique_candidates": unique_candidates,
+        "dedup_url_hits": url_dedup_hits,
+        "dedup_phash_hits": phash_dedup_hits,
+        "selected_url": selected_url,
+        "selected_score": selected_score,
+        "provider": provider,
+        "latency_ms": latency_ms,
+        "llm_healthy": llm_healthy,
+        "reject_reasons": sorted(set(reject_reasons or [])),
+    }
+    logger.log(payload)

--- a/pipeline_core/transcript.py
+++ b/pipeline_core/transcript.py
@@ -1,6 +1,7 @@
 """Transcript analysis helpers for the modular pipeline."""
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Callable, Dict, Iterable, List, Sequence
 
@@ -25,8 +26,20 @@ class TranscriptAnalyzer:
             text = str(payload.get("text", "")).strip() if isinstance(payload, dict) else ""
             if not text:
                 continue
-            start = float(payload.get("start", 0.0) or 0.0)
-            end = float(payload.get("end", start) or start)
+            start_raw = payload.get("start", 0.0) if isinstance(payload, dict) else 0.0
+            end_raw = payload.get("end", start_raw) if isinstance(payload, dict) else start_raw
+            try:
+                start = float(start_raw)
+            except (TypeError, ValueError):
+                start = 0.0
+            try:
+                end = float(end_raw)
+            except (TypeError, ValueError):
+                end = start
+            if not math.isfinite(start) or start < 0:
+                start = 0.0
+            if not math.isfinite(end):
+                end = start
             if end < start:
                 end = start
             result.append(TranscriptSegment(start=start, end=end, text=text))


### PR DESCRIPTION
## Summary
- add a runtime-aware helper for toggling the pipeline_core fetcher and emit a boot event before core runs
- harden pipeline_core orchestration, logging and transcript sanitisation to improve observability and resilience
- guard LLM integration initialisation with defensive logging

## Testing
- python -m compileall pipeline_core video_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68cbb9988a408330ac09e2bad46be574